### PR TITLE
Add TLP rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 Fomu build using the Amaranth toolchain.
 
-Try:
+To set up a Linux machine for easy passthrough:
+
+```shell
+# Allow 'plugdev' to access Fomu USB IDs
+cat extras/99-fomu.rules | sudo tee /etc/udev/rules.d/99-fomu.rules
+# Disable power-saving autosuspend on Fomu IDs
+cat extras/fomu-serial.conf | sudo tee /etc/tlp.d/fomu-serial.conf
+```
+
+Then try:
 
 ```
 source ./enter.sh
 python usb_serial.py
 ```
-
-Puts a program on the Fomu that:
-
-- Acts as a USB-serial loopback device -- echos all input
-- Blinks the green LED at 1Hz (so you know it's programmed)
-
-Use `extras/99-fomu.rules` to make the devices more accessible (non-root).
 

--- a/extra/fomu-serial.conf
+++ b/extra/fomu-serial.conf
@@ -1,0 +1,10 @@
+# fomu-serial.conf - Disable USB autosuspend for Fomu with the TinyFPGA-USB stack.
+# Seems to be causing problems?
+# See full explanation: https://linrunner.de/tlp/settings
+#
+# PARAMETER="value"
+# PARAMETER+="add value"
+
+# 
+USB_DENYLIST+="1d50:6130"
+USB_DENYLIST+="1209:5411"


### PR DESCRIPTION
I had forgotten this setup step, and had very poor notes on it.

Laptop power savings can suspend USB devices at inconvenient times. The
USB softcore we're working with on Fomu doesn't play nicely with
suspend/resume.

Add a dropin to tlp(8) to disable autosuspend for the Fomu- both
bootloader (which actually works fine with it) and serial device (which
doesn't).
