### PR TITLE
Basic packet reading for ATCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv.dir/
 venv
 .do_built.dir/
+.do_built
 *.did
 build/
 **/__pycache__/*

--- a/almost_tcp/message_hdl.py
+++ b/almost_tcp/message_hdl.py
@@ -1,0 +1,249 @@
+"""
+Almost TCP data structures: messages and packet decoder.
+
+Almost TCP is a protocol designed to tunnel data streams
+(specifically, HTTP requests) over a serial port.
+It consists of a subset of TCP's functionality,
+including reduced sizes for some fields,
+with the goal of enabling a small hardware implementation.
+
+Each ATCP message consists of a fixed-length header
+followed by variable-length data.
+
+All numeric fields are network-endian (big-endian).
+
+-   Connection-oriented: syn/synack/ack setup
+-   Single stream number, not two port numbers
+    -   Stream number probing to determine # of hardware resources available
+
+"""
+
+from amaranth import Module, Signal, unsigned, Const
+from amaranth.lib.wiring import Component, In, Out, Signature
+from amaranth.lib import stream
+from amaranth.lib.data import UnionLayout, ArrayLayout, Struct
+from amaranth.lib.fifo import SyncFIFOBuffered
+
+
+class FlagsLayout(Struct):
+    """
+    Layout of the flags in an ATCP header.
+    """
+
+    # Indicates the sender has sent all the data it will send on this stream.
+    fin: 1
+    # Indicates a desire to open a new stream,
+    # starting at 1 more than the provided sequence number.
+    syn: 1
+    # Indicates the provided stream should be immediately reset.
+    rst: 1
+    # Unused: push data to the receiver.
+    psh: 1
+    # The acknowledgement number is significant.
+    ack: 1
+    # Unused: urgent
+    urg: 1
+    # Unused: explicit congestion notification
+    ecn: 1
+    # Unused: congestion window reduced
+    cwr: 1
+
+
+class HeaderLayout(Struct):
+    """
+    Layout of a full ATCP header.
+
+    TODO: Fix byte order!
+    """
+
+    flags: FlagsLayout
+    # Stream: identity of the stream this message is intended for.
+    stream: 8
+
+    # Length of the data that follows the header.
+    length: 16
+
+    # Amount of additional data (after the acknowledged data)
+    # the sender can accept before buffering.
+    window: 16
+
+    # Sequence number: number in this stream of the
+    # first octet in the data section.
+    # The "syn" message is considered to occupy the first octet of the stream.
+    seq: 16
+    # Acknowledgement number: the next number the sender of this ACK expects.
+    ack: 16
+
+
+class PacketSignature(Signature):
+    """
+    Signature of a packet producer.
+
+    Attributes
+    ----------
+    header:         Header, out
+                    The header curently read in to the buffer.
+    stream_valid:   Out(1)
+                    High if the "stream" value from the header is valid.
+    header_valid:   Out(1)
+                    High if the whole header is valid.
+
+    data:           Stream(8), out
+                    Output stream for the body of the packet.
+                    The valid bits automatically deassert after the body
+                    has been fully read from the data stream.
+    """
+
+    def __init__(self):
+        super().__init__({
+            "input": In(stream.Signature(8)),
+            "header": Out(HeaderLayout),
+            "stream_valid": Out(1),
+            "header_valid": Out(1),
+            "data": Out(stream.Signature(8)),
+        })
+
+
+class ReadPacketStop(Component):
+    """
+    Stop on a packet-reading bus.
+
+    Each stream should have a stop on the same bus,
+    chained by their "inbus" and "outbus" connections.
+    When a stop spots a packet for its stream,
+    it tees off the input into its own PacketSignature output.
+
+    All stops get all bytes, even those not destined for this stop.
+
+    Parameters
+    ----------
+    id: int
+        Stream ID for this stop.
+
+    Attributes
+    -----------
+    inbus: Out(Stream(8))
+        Input from the bus.
+    outbus: In(Stream(8))
+        Output to the next stop on the bus.
+    packet:   Out(PacketSignature)
+        The currently-buffered packet.
+    """
+
+    inbus: In(stream.Signature(8))
+    outbus: Out(stream.Signature(8))
+    packet: Out(PacketSignature())
+
+    def __init__(self, id: int):
+        super().__init__()
+        self._stream_id = id
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # Our header may be locally valid
+        # but not a match for the stream.
+        local_header_valid = Signal(1)
+        header_valid_and_matched = self.packet.header_valid
+        stream_valid = self.packet.stream_valid
+        data = self.packet.data
+        stream_match = Signal(1)
+
+        # We add a 1-slot FIFO to the bus output
+        # to avoid long combinatorial paths.
+        m.submodules.outbus = outbus = SyncFIFOBuffered(width=8, depth=1)
+        m.d.comb += [
+            self.outbus.payload.eq(outbus.r_data),
+            self.outbus.valid.eq(outbus.r_rdy),
+            outbus.r_en.eq(self.outbus.ready),
+        ]
+        # We don't do the same on the "local data" side;
+        # we assume the reader of the body will have its own
+        # (connection-level) buffer.
+
+        # Our state machine: what byte do we read in to next?
+        byte = Signal(4)
+        m.d.comb += [
+            # Stream is valid once we've read byte[1]
+            stream_valid.eq(byte > 1),
+            stream_match.eq(
+                stream_valid & (
+                    self.packet.header.stream == Const(self._stream_id)
+                )
+            ),
+            # Whole header is valid once we've read byte[9]
+            local_header_valid.eq(byte > 9),
+            header_valid_and_matched.eq(stream_match & local_header_valid),
+            # We always tee data to both outputs:
+            data.payload.eq(self.inbus.payload),
+            outbus.w_data.eq(self.inbus.payload),
+            # But by default, produce no transfers.
+            self.inbus.ready.eq(0),
+            data.valid.eq(0),
+            outbus.w_en.eq(0),
+        ]
+        remaining_len = Signal(16)
+
+        mixed_view = UnionLayout(
+            {
+                "bytes": ArrayLayout(unsigned(8), 10),
+                "header": HeaderLayout
+            })
+        network = Signal(HeaderLayout)
+        pun = mixed_view(network)
+
+        # We combinatorially convert between the network order
+        # and little-endian.
+        m.d.comb += [
+            self.packet.header.flags.eq(network.flags),
+            self.packet.header.stream.eq(network.stream),
+            self.packet.header.length[0:8].eq(network.length[8:16]),
+            self.packet.header.length[8:16].eq(network.length[0:8]),
+            self.packet.header.window[0:8].eq(network.window[8:16]),
+            self.packet.header.window[8:16].eq(network.window[0:8]),
+            self.packet.header.seq[0:8].eq(network.seq[8:16]),
+            self.packet.header.seq[8:16].eq(network.seq[0:8]),
+            self.packet.header.ack[0:8].eq(network.ack[8:16]),
+            self.packet.header.ack[8:16].eq(network.ack[0:8]),
+        ]
+
+        # We may have to wait for the next stop on the bus, or our local stop,
+        # before we take from the input.
+        # In either case, every byte from the inbus goes to the outbus.
+        can_transfer = Signal(1)
+        m.d.comb += [
+            outbus.w_en.eq(can_transfer),
+            self.inbus.ready.eq(can_transfer),
+        ]
+        # State machine is encoded in byte count & stream match.
+        with m.If(~local_header_valid):
+            # Read in a byte to the header,
+            # not to local data.
+            m.d.comb += [
+                can_transfer.eq(self.inbus.valid & outbus.w_rdy),
+                data.valid.eq(0),
+            ]
+            with m.If(can_transfer):
+                # Byte transferred at the end of this cycle.
+                m.d.sync += [
+                    byte.eq(byte + 1),
+                    pun.bytes[byte].eq(self.inbus.payload),
+                ]
+                with m.If(byte == 4):
+                    # Capture the length.
+                    m.d.sync += remaining_len.eq(self.packet.header.length)
+        with m.Else():
+            # Forward bytes around the bus,
+            # and optionally to the local channel too.
+            m.d.comb += [
+                can_transfer.eq(self.inbus.valid &
+                                outbus.w_rdy & data.ready),
+                data.valid.eq(can_transfer),
+            ]
+
+            with m.If(can_transfer):
+                m.d.sync += remaining_len.eq(remaining_len - 1)
+                with m.If(remaining_len == 1):
+                    m.d.sync += byte.eq(0)
+
+        return m

--- a/almost_tcp/message_host.py
+++ b/almost_tcp/message_host.py
@@ -2,13 +2,9 @@
 Host-side implementation of the Almost TCP protocol.
 """
 
-import logging
-import asyncio
 from dataclasses import dataclass
-from typing import Dict, Optional
 import itertools
 import struct
-from asyncio import locks
 
 
 class NotEnoughDataError(Exception):

--- a/almost_tcp/message_host.py
+++ b/almost_tcp/message_host.py
@@ -1,0 +1,138 @@
+"""
+Host-side implementation of the Almost TCP protocol.
+"""
+
+import logging
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, Optional
+import itertools
+import struct
+from asyncio import locks
+
+
+class NotEnoughDataError(Exception):
+    """
+    Exception raised when there is not enough data to encode/decode a packet.
+    """
+
+    def __init__(self, message=""):
+        if self.message:
+            self.add_note(message)
+
+
+class ConnectionFailedError(Exception):
+    """
+    Exception raised when a connection cannot be established.
+    """
+
+    def __init__(self, message=""):
+        if self.message:
+            self.add_note(message)
+
+
+class AlreadyFinishedError(Exception):
+    """
+    When the client attempts an operation after finishing the connection.
+    """
+
+    def __init__(self, message=""):
+        if self.message:
+            self.add_note(message)
+
+
+@dataclass
+class Flags:
+    """
+    Host-side codec for the flags structure.
+    """
+    fin: bool = False
+    syn: bool = False
+    rst: bool = False
+    psh: bool = False
+    ack: bool = False
+    urg: bool = False
+    ecn: bool = False
+    cwr: bool = False
+
+    def encode(self):
+        x = 0
+        for (i, v) in itertools.zip_longest(range(0, 8), [
+                self.fin, self.syn, self.rst, self.psh,
+                self.ack, self.urg, self.ecn, self.cwr]):
+            x |= v << i
+
+        return bytes([x])
+
+    def decode(buffer):
+        z = buffer[0]
+        x = Flags()
+        x.fin = ((z >> 0) & 1) == 1
+        x.syn = ((z >> 1) & 1) == 1
+        x.rst = ((z >> 2) & 1) == 1
+        x.psh = ((z >> 3) & 1) == 1
+        x.ack = ((z >> 4) & 1) == 1
+        x.urg = ((z >> 5) & 1) == 1
+        x.ecn = ((z >> 6) & 1) == 1
+        x.cwr = ((z >> 7) & 1) == 1
+        return x
+
+
+@dataclass
+class Header:
+    """
+    Almost TCP header structure.
+    """
+
+    # Number of bytes in the header.
+    BYTES = 10
+    FORMAT = "!BHHHH"
+
+    flags: Flags
+    stream: int
+    length: int = 0
+    window: int = 0
+    seq: int = 0
+    ack: int = 0
+
+    def __len__(self):
+        return Header.BYTES
+
+    def encode(self):
+        return self.flags.encode() + struct.pack(
+            Header.FORMAT,
+            self.stream, self.length, self.window, self.seq, self.ack)
+
+    def decode(buffer):
+        if len(buffer) < Header.BYTES:
+            raise NotEnoughDataError(
+                f"not enough bytes for header: {len(buffer)} < 10")
+        flags = Flags.decode(buffer)
+        (stream, length, window, seq, ack) = struct.unpack(
+            Header.FORMAT, buffer[1:])
+        return Header(flags, stream, length, window, seq, ack)
+
+
+@dataclass
+class Packet:
+    """
+    Almost TCP packet structure.
+    """
+    header: Header
+    body: bytes
+
+    def __len__(self):
+        return len(self.header) + len(self.body)
+
+    def decode(buffer):
+        header = Header.decode(buffer)
+        tail = buffer[Header.BYTES:]
+        if len(tail) < header.length:
+            raise NotEnoughDataError(
+                f"not enough bytes for body: {len(tail)} < {header.length}")
+        body = tail[:header.length]
+
+        return Packet(header, body)
+
+    def encode(self):
+        return self.header.encode() + self.body

--- a/almost_tcp/message_host_test.py
+++ b/almost_tcp/message_host_test.py
@@ -1,0 +1,31 @@
+"""
+Host-side tests for ATCP messages.
+"""
+
+import unittest
+from message_host import Flags, Header
+
+
+class TestMakeLayout(unittest.TestCase):
+
+    def test_make_flags(self):
+        layout = Flags()
+        layout.fin = True
+        layout.rst = True
+        layout.ack = True
+        layout.ecn = True
+
+        self.assertEqual(layout.encode(), bytes([0x55]))
+
+    def test_decode_header(self):
+        data = bytes([0xAA, 0x98, 0x01, 0x02, 0x03,
+                     0x04, 0x04, 0x05, 0x06, 0x07])
+        header = Header.decode(data)
+        self.assertEqual(header.flags.syn, True)
+        self.assertEqual(header.flags.fin, False)
+        self.assertEqual(header.stream, 0x98)
+        self.assertEqual(header.length, 0x0102)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/almost_tcp/packet_fixtures.py
+++ b/almost_tcp/packet_fixtures.py
@@ -1,0 +1,108 @@
+"""
+Test fixtures for sending and receiving packets and streams.
+"""
+import random
+from message_host import Packet
+
+
+class StreamCollector:
+    """
+    Collects data from an Amaranth data stream.
+    """
+
+    # Set to true to apply random backpressure.
+    # Otherwise, the stream is always ready.
+    random_backpressure: bool = False
+
+    # The collected body.
+    body: bytes = bytes()
+
+    def __init__(self, random_backpressure=False):
+        super().__init__()
+        self.random_backpressure = random_backpressure
+
+    def is_ready(self):
+        """
+        Return a ready value, possibly incorporating random backpressure.
+        """
+
+        if self.random_backpressure:
+            return random.randint(0, 1)
+        else:
+            return 1
+
+    def collect(self, stream):
+        async def collector(ctx):
+            ready = self.is_ready()
+            ctx.set(stream.ready, ready)
+            async for clk_edge, rst_value, valid, payload in ctx.tick().sample(
+                    stream.valid, stream.payload):
+                if rst_value or (not clk_edge):
+                    continue
+                if ready == 1 and valid == 1:
+                    # We just transferred a payload byte.
+                    self.body = self.body + bytes([payload])
+                ready = self.is_ready()
+                # ready = 1
+                ctx.set(stream.ready, ready)
+        return collector
+
+    def assert_eq(self, other: bytes):
+        got = self.body
+        want = other
+        assert len(got) == len(want), f"got: {len(got)} want: {len(want)}"
+        for b in range(len(want)):
+            assert got[b] == want[b]
+
+    def __len__(self):
+        return len(self.body)
+
+
+class PacketSender:
+    """
+    Transmit a packet into an Amaranth data stream.
+    """
+
+    # Set to true to apply random delays to input.
+    # Otherwise, the stream is always ready.
+    random_delay: bool = False
+
+    # The collected body.
+    body: bytes = bytes()
+
+    def __init__(self, random_delay=False):
+        super().__init__()
+        self.random_delay = random_delay
+
+    def is_valid(self):
+        """
+        Return a valid value, possibly incorporating random delay.
+        """
+
+        if self.random_delay:
+            return random.randint(0, 1)
+        else:
+            return 1
+
+    def send(self, packet: Packet, stream):
+        b = packet.encode()
+
+        async def sender(ctx):
+            counter = 0
+            valid = self.is_valid()
+            ctx.set(stream.valid, valid)
+            ctx.set(stream.payload, b[counter])
+            async for clk_edge, rst_value, ready in (
+                    ctx.tick().sample(stream.ready)):
+                if ready == 1 and valid == 1:
+                    # We just transferred the byte.
+                    counter += 1
+                # Update the payload:
+                if counter < len(b):
+                    ctx.set(stream.payload, b[counter])
+                else:
+                    ctx.set(stream.payload, counter % 256)
+                valid = self.is_valid()
+                ctx.set(stream.valid, valid)
+
+        return sender

--- a/almost_tcp/packet_multistop_test.py
+++ b/almost_tcp/packet_multistop_test.py
@@ -1,0 +1,128 @@
+from amaranth.sim import Simulator
+from amaranth.lib.wiring import Component, In, Out, connect
+from amaranth import Module
+from amaranth.lib import stream
+
+from message_hdl import ReadPacketStop, PacketSignature
+from message_host import Header, Packet, Flags
+from packet_fixtures import StreamCollector, MultiPacketSender
+
+
+class AtcpReadBus(Component):
+
+    inbus: In(stream.Signature(8))
+    three: Out(PacketSignature())
+    five: Out(PacketSignature())
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.three = three = ReadPacketStop(id=3)
+        m.submodules.five = five = ReadPacketStop(id=5)
+        # Export the packet interfaces:
+        self.three = three.packet
+        self.five = five.packet
+
+        # Chain the bus:
+        self.inbus = three.inbus
+        connect(m, three.outbus, five.inbus)
+        # And allow the last stop to fall on the floor
+        m.d.comb += five.outbus.ready.eq(1)
+
+        return m
+
+
+dut = AtcpReadBus()
+
+
+def bench_stream3(dut, refpkt: Packet):
+    async def bench(ctx):
+        packet = dut.three
+        while ctx.get(packet.stream_valid) != 1:
+            await ctx.tick()
+        assert ctx.get(packet.stream_valid)
+        assert ctx.get(packet.header.stream) == refpkt.header.stream
+        assert not ctx.get(packet.header_valid)
+
+        while ctx.get(packet.header_valid) != 1:
+            await ctx.tick()
+        assert ctx.get(packet.stream_valid)
+        assert ctx.get(packet.header_valid)
+        hdr = refpkt.header
+        assert ctx.get(packet.header.flags.fin) == hdr.flags.fin
+        assert ctx.get(packet.header.flags.urg) == hdr.flags.urg
+        assert ctx.get(packet.header.flags.rst) == hdr.flags.rst
+        assert ctx.get(packet.header.flags.cwr) == hdr.flags.cwr
+        assert ctx.get(packet.header.flags.psh) == hdr.flags.psh
+        assert ctx.get(packet.header.flags.ack) == hdr.flags.ack
+        assert ctx.get(packet.header.flags.syn) == hdr.flags.syn
+        assert ctx.get(packet.header.flags.ack) == hdr.flags.ack
+        assert ctx.get(packet.header.stream) == hdr.stream
+        assert ctx.get(packet.header.length) == hdr.length
+        assert ctx.get(packet.header.window) == hdr.window
+        assert ctx.get(packet.header.seq) == hdr.seq
+        assert ctx.get(packet.header.ack) == hdr.ack
+
+        # Continue driving the simulation until the input is complete.
+        while ctx.get(dut.inbus.valid):
+            await ctx.tick()
+        # ...and until the output is complete.
+        while ctx.get(dut.five.data.valid):
+            await ctx.tick()
+
+    return bench
+
+
+def sim_main():
+    import sys
+
+    sim = Simulator(dut)
+    three_collector = StreamCollector(random_backpressure=False)
+    five_collector = StreamCollector(random_backpressure=False)
+    # We don't delay in the input, so we can detect
+    # the sender's completion from within the testbench.
+    sender = MultiPacketSender(random_delay=False)
+    data = bytes(i % 256 for i in range(0, 50))
+    p = Packet(
+        Header(
+            Flags(cwr=True, urg=True, rst=True, fin=True),
+            stream=3,
+            length=len(data),
+            window=770,
+            seq=4097,
+            ack=12290,
+        ),
+        body=data
+    )
+    p0 = Packet(
+        Header(
+            Flags(fin=True),
+            stream=5,
+            length=len(data[:40]),
+            window=80,
+            seq=123,
+            ack=456,
+        ),
+        body=data[:40]
+    )
+
+    sim.add_clock(1e-6)
+
+    sim.add_process(three_collector.collect(dut.three.data))
+    sim.add_process(five_collector.collect(dut.five.data))
+    sim.add_process(sender.send([p0, p, p0], dut.inbus))
+    sim.add_testbench(bench_stream3(dut, p))
+
+    with sim.write_vcd(sys.stdout):
+        sim.run()
+
+    # After the simulation completes -- the sender is done --
+    # we still should only have collected only
+    # the data from the packet on stream 3...
+    three_collector.assert_eq(p.body)
+    # ...and the data from both stream-5 packets on stream 5.
+    five_collector.assert_eq(2 * p0.body)
+
+
+if __name__ == "__main__":
+    sim_main()

--- a/almost_tcp/packet_stops_test.py
+++ b/almost_tcp/packet_stops_test.py
@@ -1,0 +1,83 @@
+from amaranth.sim import Simulator
+
+from message_hdl import ReadPacketStop
+from message_host import Header, Packet, Flags
+from packet_fixtures import StreamCollector, PacketSender
+
+dut = ReadPacketStop(id=3)
+
+
+def bench(dut,
+          body_collector: StreamCollector,
+          packet_collector: StreamCollector,
+          refpkt: Packet):
+    async def bench(ctx):
+        packet = dut.packet
+        while ctx.get(packet.stream_valid) != 1:
+            await ctx.tick()
+        assert ctx.get(packet.stream_valid)
+        assert ctx.get(packet.header.stream) == refpkt.header.stream
+        assert not ctx.get(packet.header_valid)
+
+        while ctx.get(packet.header_valid) != 1:
+            await ctx.tick()
+        assert ctx.get(packet.stream_valid)
+        assert ctx.get(packet.header_valid)
+        hdr = refpkt.header
+        assert ctx.get(packet.header.flags.fin) == hdr.flags.fin
+        assert ctx.get(packet.header.flags.urg) == hdr.flags.urg
+        assert ctx.get(packet.header.flags.rst) == hdr.flags.rst
+        assert ctx.get(packet.header.flags.cwr) == hdr.flags.cwr
+        assert ctx.get(packet.header.flags.psh) == hdr.flags.psh
+        assert ctx.get(packet.header.flags.ack) == hdr.flags.ack
+        assert ctx.get(packet.header.flags.syn) == hdr.flags.syn
+        assert ctx.get(packet.header.flags.ack) == hdr.flags.ack
+        assert ctx.get(packet.header.stream) == hdr.stream
+        assert ctx.get(packet.header.length) == hdr.length
+        assert ctx.get(packet.header.window) == hdr.window
+        assert ctx.get(packet.header.seq) == hdr.seq
+        assert ctx.get(packet.header.ack) == hdr.ack
+
+        # Wait until all the data are read:
+        while ctx.get(packet.header_valid):
+            await ctx.tick()
+        # Wait until the tail is drained too,
+        # which is probably at least one cycle later:
+        while len(packet_collector) < len(refpkt.encode()):
+            await ctx.tick()
+
+        body_collector.assert_eq(refpkt.body)
+        packets_collector.assert_eq(refpkt.encode())
+    return bench
+
+
+# Doesn't appear to be a way to _remove_ a testbench;
+# I guess .reset() is "just" to allow a different initial state?
+if __name__ == "__main__":
+    import sys
+
+    sim = Simulator(dut)
+    body_collector = StreamCollector(random_backpressure=True)
+    packets_collector = StreamCollector(random_backpressure=True)
+    sender = PacketSender(random_delay=True)
+    data = bytes(i % 256 for i in range(0, 260))
+    p = Packet(
+        Header(
+            Flags(cwr=True, urg=True, rst=True, fin=True),
+            stream=3,
+            length=len(data),
+            window=770,
+            seq=4097,
+            ack=12290,
+        ),
+        body=data
+    )
+
+    sim.add_clock(1e-6)
+    sim.add_process(sender.send(p, dut.inbus))
+    sim.add_process(body_collector.collect(dut.packet.data))
+    sim.add_process(packets_collector.collect(dut.outbus))
+    sim.add_testbench(bench(dut, body_collector, packets_collector, p))
+
+    with sim.write_vcd(sys.stdout):
+        sim.run()


### PR DESCRIPTION
- Create packet formats on the host and device sides.
  Basically the TCP header (RFC 9293), just a little smaller
  and skipping some baggage.
- Create a bus-stop-based decoder for the packets.
  Each stop looks for packets matching its stream,
  captures their headers, and tees them to a local stream;
  but for convenience, all packets circulate the entire bus.
- Include some test fixtures for sending & receiving packets.

Not implemented: any sort of connection management, on either end.
