### PR TITLE
Add a CI flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Run tests
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run tests
+      run: |
+        ./do tests
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cat extras/fomu-serial.conf | sudo tee /etc/tlp.d/fomu-serial.conf
 Then try:
 
 ```
-source ./enter.sh
+. ./enter.sh
 python usb_serial.py
 ```
 

--- a/enter.sh
+++ b/enter.sh
@@ -1,6 +1,6 @@
 
 ./do venv
-source ./venv.dir/bin/activate
+. ./venv.dir/bin/activate
 export YOSYS=yowasp-yosys
 export NEXTPNR_ICE40=yowasp-nextpnr-ice40
 export ICEPACK=yowasp-icepack

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,11 @@ git+https://github.com/amaranth-lang/amaranth-boards@9d97c4816288c9c2cc304d9280c
 
 git+https://github.com/amaranth-lang/amaranth-soc@5c43cf58f15d9cd9c69ff83c97997708d386b2dc
 
-# Support for amaranth 0.5
-
+# Support for amaranth 0.5;
+# This is merged to mainline
 git+https://github.com/greatscottgadgets/luna@1462160ba66302aaae69dca9e54fd71498a8b3ef
 
 regex
+# Dev dependencies:
+flake8
+pytest

--- a/tests.do
+++ b/tests.do
@@ -4,6 +4,8 @@ find . -name '*_test.py' \
 | sed 's/_test.py$/.vcd/' \
 | xargs redo-ifchange
 
+source ./enter.sh
+
 # stop the build if there are Python syntax errors or undefined names
 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/tests.do
+++ b/tests.do
@@ -1,12 +1,15 @@
 
+# TODO: How do we get it to ignore the venv?
+# stop the build if there are Python syntax errors or undefined names
+# flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+# flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 find . -name '*_test.py' \
 | grep -v venv \
 | sed 's/_test.py$/.vcd/' \
 | xargs redo-ifchange
 
-source ./enter.sh
+. ./enter.sh
 
-# stop the build if there are Python syntax errors or undefined names
-flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+

--- a/tests.do
+++ b/tests.do
@@ -4,3 +4,7 @@ find . -name '*_test.py' \
 | sed 's/_test.py$/.vcd/' \
 | xargs redo-ifchange
 
+# stop the build if there are Python syntax errors or undefined names
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
Basic exercise of the `./do tests` target.

Passes locally with `gh act`.