### PR TITLE
Improvements and tests of packet fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 build/
 **/__pycache__/*
 *.vcd
+**/.hypothesis/

--- a/almost_tcp/message_hdl.py
+++ b/almost_tcp/message_hdl.py
@@ -216,8 +216,8 @@ class ReadPacketStop(Component):
         network = Signal(HeaderLayout)
         pun = mixed_view(network)
         m.submodules.swizzle = swizzle = HeaderSwizzle()
-        swizzle.inheader = network
-        self.packet.header = swizzle.outheader
+        m.d.comb += [swizzle.inheader.eq(network),
+                     self.packet.header.eq(swizzle.outheader)]
 
         # We may have to wait for the next stop on the bus, or our local stop,
         # before we take from the input.

--- a/almost_tcp/packet_fixtures.py
+++ b/almost_tcp/packet_fixtures.py
@@ -2,7 +2,7 @@
 Test fixtures for sending and receiving packets and streams.
 """
 import random
-from message_host import Packet, Header, Flags
+from almost_tcp.message_host import Packet, Header, Flags
 from typing import List
 from functools import reduce
 from hypothesis import strategies as st
@@ -35,7 +35,8 @@ def arbitrary_packet(
     return Packet(header=header, body=body)
 
 
-st.register_type_strategy(Packet, arbitrary_packet())
+# Apparently it doesn't work to register within an import. Boo.
+# st.register_type_strategy(Packet, arbitrary_packet())
 
 
 class StreamCollector:

--- a/almost_tcp/packet_fixtures.py
+++ b/almost_tcp/packet_fixtures.py
@@ -79,7 +79,7 @@ class StreamCollector:
                     self.body = self.body + bytes([payload])
                     ready = self.is_ready()
                 else:
-                    # Maybe become ready, don't become un-ready.
+                    # Don't become un-ready until we transver a payload byte.
                     ready = ready | self.is_ready()
                 ctx.set(stream.ready, ready)
         return collector
@@ -149,7 +149,7 @@ class PacketCollector:
                     data = data + bytes([payload])
                     ready = self.is_ready()
                 else:
-                    # Become ready, but don't become un-ready.
+                    # Don't become un-ready until we transfer a payload byte
                     ready = ready | self.is_ready()
                 ctx.set(stream.ready, ready)
 
@@ -297,7 +297,7 @@ class MultiPacketSender:
                     counter += 1
                     valid = self.is_valid()
                 else:
-                    # Maybe ready the byte.
+                    # Don't become in-valid until the byte is transferred.
                     valid = valid | self.is_valid()
                 # Update the payload:
                 if counter >= len(b):

--- a/almost_tcp/packet_fixtures.py
+++ b/almost_tcp/packet_fixtures.py
@@ -2,14 +2,45 @@
 Test fixtures for sending and receiving packets and streams.
 """
 import random
-from almost_tcp.message_host import Packet
+from message_host import Packet, Header, Flags
 from typing import List
 from functools import reduce
+from hypothesis import strategies as st
+
+__all__ = ["arbitrary_packet", "StreamCollector",
+           "PacketCollector", "PacketSender", "MultiPacketSender"]
+
+
+@st.composite
+def arbitrary_packet(
+    draw: st.DrawFn,
+    flags=st.integers(0, 255),
+    stream=st.integers(0, 255),
+    window=st.integers(0, (2**16)-1),
+    seq=st.integers(0, (2**16)-1),
+    ack=st.integers(0, (2**16)-1),
+    body=st.binary(),
+):
+    """
+    Hypothesis strategy for generating an arbitrary packet.
+    The length matches the data length.
+    """
+    body = draw(body)
+    length = len(body)
+    header = Header(
+        flags=Flags.decode(bytes([draw(flags)])),
+        stream=draw(stream), window=draw(window), seq=draw(seq), ack=draw(ack),
+        length=length,
+    )
+    return Packet(header=header, body=body)
+
+
+st.register_type_strategy(Packet, arbitrary_packet())
 
 
 class StreamCollector:
     """
-    Collects data from an Amaranth data stream.
+    Collects raw data from an Amaranth data stream.
     """
 
     # Set to true to apply random backpressure.
@@ -43,7 +74,10 @@ class StreamCollector:
                 if ready == 1 and valid == 1:
                     # We just transferred a payload byte.
                     self.body = self.body + bytes([payload])
-                ready = self.is_ready()
+                    ready = self.is_ready()
+                else:
+                    # Maybe become ready, don't become un-ready.
+                    ready = ready | self.is_ready()
                 ctx.set(stream.ready, ready)
         return collector
 
@@ -68,18 +102,93 @@ class StreamCollector:
         return len(self.body)
 
 
+class PacketCollector:
+    """
+    Collect packets from a data stream.
+    """
+    # Set to true to apply random backpressure.
+    # Otherwise, the stream is always ready.
+    random_backpressure: bool = False
+
+    packets: List[Packet]
+
+    def __init__(self, stream, random_backpressure=False):
+        super().__init__()
+        self.random_backpressure = random_backpressure
+        self._stream = stream
+        self.packets = []
+
+    def is_ready(self):
+        """
+        Return a ready value, possibly incorporating random backpressure.
+        """
+
+        if self.random_backpressure:
+            return random.randint(0, 1)
+        else:
+            return 1
+
+    def recv(self):
+        async def receiver(ctx):
+            stream = self._stream
+            data = bytes()
+
+            header = None
+
+            ready = self.is_ready()
+            ctx.set(stream.ready, ready)
+            async for clk_edge, rst_value, valid, payload in ctx.tick().sample(
+                    stream.valid, stream.payload):
+                if rst_value or (not clk_edge):
+                    continue
+                if ready == 1 and valid == 1:
+                    # We just transferred a payload byte.
+                    data = data + bytes([payload])
+                    ready = self.is_ready()
+                else:
+                    # Become ready, but don't become un-ready.
+                    ready = ready | self.is_ready()
+                ctx.set(stream.ready, ready)
+
+                if header is None and len(data) == Header.BYTES:
+                    # Accumulate into a header.
+                    header = Header.decode(data)
+                    data = bytes()
+                elif header is not None and len(data) == header.length:
+                    # Completed a packet.
+                    self.packets.append(Packet(header=header, body=data))
+                    header = None
+                    data = bytes()
+
+        return receiver
+
+
 class MultiPacketSender:
     """
-    Transmit multiple packets into an Amaranth data stream.
+    Transmit multiple packets into an Amaranth object.
     """
 
     # Set to true to apply random delays to input.
     # Otherwise, the stream is always ready.
     random_delay: bool = False
 
-    def __init__(self, random_delay=False):
+    def __init__(self,
+                 random_delay=False,
+                 stream=None,
+                 packet=None
+                 ):
+        """
+        Construct a packet sender.
+
+        Arguments:
+        random_delay: Introduce random delay before bytes are ready.
+        stream: Amaranth stream.Signature(8) component to write the packets to.
+        packet: PacketSignature() component to write packets to.
+        """
         super().__init__()
         self.random_delay = random_delay
+        self._stream = stream
+        self._packet = packet
 
     def is_valid(self):
         """
@@ -91,11 +200,70 @@ class MultiPacketSender:
         else:
             return 1
 
-    def send(self, packets: List[Packet], stream):
+    def send(self, packets: List[Packet]):
+        if self._stream is not None:
+            return self.send_to_stream(packets)
+        elif self._packet is not None:
+            return self.send_packets(packets)
+        else:
+            assert False, "MultiPacketSender is not configured with any output"
+
+    def send_packets(self, packets: List[Packet]):
+        """
+        Transmit the packets serially into the constructor-provided
+        packet interface.
+        """
+        async def sender(ctx):
+            iface = self._packet
+            for packet in packets:
+                # TODO: Hack here -- we haven't actually transmitted length etc.
+                ctx.set(iface.header.flags.fin, 1)
+
+                # Mark the header present:
+                ctx.set(iface.header_valid, 1)
+
+                counter = 0
+                # We have one cycle before the body is ready
+                # just to let the loop below be tidy.
+                valid = 0
+                async for clk_edge, rst_value, ready in (
+                        ctx.tick().sample(iface.data.ready)):
+                    if ready == 1 and valid == 1:
+                        counter += 1
+                        valid = self.is_valid()
+                    else:
+                        # Become valid, but don't drop validity.
+                        valid = valid | self.is_valid()
+                    if counter >= len(packet.body):
+                        break
+
+                    ctx.set(iface.data.payload, packet.body[counter])
+                    ctx.set(iface.data.valid, valid)
+
+                ctx.set(iface.data.valid, 0)
+                ctx.set(iface.header_valid, 0)
+
+                # Spend at least once cycle with header !valid
+                # before moving to the next example.
+                async for _clk_edge, _rst_value, _ready in (
+                        ctx.tick().sample(iface.data.ready)):
+                    pass
+
+        return sender
+
+    def send_to_stream(self, packets: List[Packet]):
+        """
+        Transmit the given packets serially into stream.
+        """
+        stream = self._stream
         byte_arrays = [p.encode() for p in packets]
         b = reduce(lambda a, b: a + b, byte_arrays, bytes())
 
         async def sender(ctx):
+            ctx.set(stream.valid, 0)
+            if len(b) == 0:
+                return
+
             counter = 0
             valid = self.is_valid()
             ctx.set(stream.valid, valid)
@@ -105,11 +273,14 @@ class MultiPacketSender:
                 if ready == 1 and valid == 1:
                     # We just transferred the byte.
                     counter += 1
+                    valid = self.is_valid()
+                else:
+                    # Maybe ready the byte.
+                    valid = valid | self.is_valid()
                 # Update the payload:
                 if counter >= len(b):
                     break
                 ctx.set(stream.payload, b[counter])
-                valid = self.is_valid()
                 ctx.set(stream.valid, valid)
             # Break: end of stream.
             ctx.set(stream.valid, 0)
@@ -119,8 +290,8 @@ class MultiPacketSender:
 
 class PacketSender(MultiPacketSender):
     """
-    Transmit a single packet into an Amaranth data stream.
+    Transmit a single packet into Amaranth.
     """
 
-    def send(self, packet: Packet, stream):
-        return super().send([packet], stream)
+    def send(self, packet: Packet):
+        return super().send([packet])

--- a/almost_tcp/packet_fixtures_test.py
+++ b/almost_tcp/packet_fixtures_test.py
@@ -20,7 +20,7 @@ def test_stream_send_structured_receive(packets: List[Packet]):
     sender = MultiPacketSender(random_delay=True, stream=dut.w_stream)
     # Turning on random backpressure here causes the tests to take A Long Time.
     # ...I guess because if there's *random* backpressure, there's a set of
-    # random sequences which reusilt in it taking an arbitrarily long time to
+    # random sequences which results in it taking an arbitrarily long time to
     # complete. Though, that's *arbitrary*, not *random*.
     # TODO: Double-check on packpressure
     #

--- a/almost_tcp/packet_fixtures_test.py
+++ b/almost_tcp/packet_fixtures_test.py
@@ -1,0 +1,56 @@
+from amaranth.lib.fifo import SyncFIFOBuffered
+from amaranth.sim import Simulator
+from hypothesis import given
+from packet_fixtures import MultiPacketSender, PacketCollector
+from message_host import Packet
+from typing import List
+import sys
+
+
+@given(packets=...)
+def test_stream_send_structured_receive(packets: List[Packet]):
+    """
+    Test a round-trip between MultiPacketSender (Packet -> stream) and
+    PacketCollector (stream->Packet), via a FIFO.
+    """
+
+    # All we need is a buffer for this to work.
+    # Depth chosen arbitrarily.
+    dut = SyncFIFOBuffered(width=8, depth=2)
+    sender = MultiPacketSender(random_delay=True, stream=dut.w_stream)
+    # Turning on random backpressure here causes the tests to take A Long Time.
+    # ...I guess because if there's *random* backpressure, there's a set of
+    # random sequences which reusilt in it taking an arbitrarily long time to
+    # complete. Though, that's *arbitrary*, not *random*.
+    # TODO: Double-check on packpressure
+    #
+    # Apparently Hypothesis handles the `random` RNG:
+    # > By default, Hypothesis will handle the global `random` and
+    # > `numpy.random` random number generators for you,
+    # https://hypothesis.readthedocs.io/en/latest/details.html#making-random-code-deterministic
+    #
+    receiver = PacketCollector(
+        random_backpressure=False, stream=dut.r_stream)
+
+    async def driver(ctx):
+        while len(receiver.packets) < len(packets):
+            await ctx.tick()
+
+    sim = Simulator(dut)
+    sim.add_clock(1e-6)
+    sim.add_process(sender.send(packets))
+    sim.add_process(receiver.recv())
+    sim.add_testbench(driver)
+
+    with sim.write_vcd(sys.stdout):
+        sim.run()
+
+    assert len(receiver.packets) == len(packets)
+    for i in range(len(packets)):
+        want = packets[i]
+        got = receiver.packets[i]
+        assert got == want
+
+
+if __name__ == "__main__":
+    test_stream_send_structured_receive()

--- a/almost_tcp/packet_fixtures_test.py
+++ b/almost_tcp/packet_fixtures_test.py
@@ -1,10 +1,14 @@
 from amaranth.lib.fifo import SyncFIFOBuffered
 from amaranth.sim import Simulator
-from hypothesis import given
-from packet_fixtures import MultiPacketSender, PacketCollector
+from hypothesis import given, strategies
+from packet_fixtures import (
+    MultiPacketSender, PacketCollector, arbitrary_packet)
 from message_host import Packet
 from typing import List
 import sys
+
+# This doesn't work via import, apparently
+strategies.register_type_strategy(Packet, arbitrary_packet())
 
 
 @given(packets=...)

--- a/almost_tcp/packet_multistop_test.py
+++ b/almost_tcp/packet_multistop_test.py
@@ -2,7 +2,7 @@ from amaranth.sim import Simulator
 from amaranth.lib.wiring import Component, In, Out, connect
 from amaranth import Module
 from amaranth.lib import stream
-
+import sys
 from message_hdl import ReadPacketStop, PacketSignature
 from message_host import Header, Packet, Flags
 from packet_fixtures import StreamCollector, MultiPacketSender
@@ -32,58 +32,19 @@ class AtcpReadBus(Component):
         return m
 
 
-dut = AtcpReadBus()
-
-
-def bench_stream3(dut, refpkt: Packet):
-    async def bench(ctx):
-        packet = dut.three
-        while ctx.get(packet.stream_valid) != 1:
-            await ctx.tick()
-        assert ctx.get(packet.stream_valid)
-        assert ctx.get(packet.header.stream) == refpkt.header.stream
-        assert not ctx.get(packet.header_valid)
-
-        while ctx.get(packet.header_valid) != 1:
-            await ctx.tick()
-        assert ctx.get(packet.stream_valid)
-        assert ctx.get(packet.header_valid)
-        hdr = refpkt.header
-        assert ctx.get(packet.header.flags.fin) == hdr.flags.fin
-        assert ctx.get(packet.header.flags.urg) == hdr.flags.urg
-        assert ctx.get(packet.header.flags.rst) == hdr.flags.rst
-        assert ctx.get(packet.header.flags.cwr) == hdr.flags.cwr
-        assert ctx.get(packet.header.flags.psh) == hdr.flags.psh
-        assert ctx.get(packet.header.flags.ack) == hdr.flags.ack
-        assert ctx.get(packet.header.flags.syn) == hdr.flags.syn
-        assert ctx.get(packet.header.flags.ack) == hdr.flags.ack
-        assert ctx.get(packet.header.stream) == hdr.stream
-        assert ctx.get(packet.header.length) == hdr.length
-        assert ctx.get(packet.header.window) == hdr.window
-        assert ctx.get(packet.header.seq) == hdr.seq
-        assert ctx.get(packet.header.ack) == hdr.ack
-
-        # Continue driving the simulation until the input is complete.
-        while ctx.get(dut.inbus.valid):
-            await ctx.tick()
-        # ...and until the output is complete.
-        while ctx.get(dut.five.data.valid):
-            await ctx.tick()
-
-    return bench
-
-
 def sim_main():
-    import sys
+    dut = AtcpReadBus()
 
     sim = Simulator(dut)
-    three_collector = StreamCollector(random_backpressure=False)
-    five_collector = StreamCollector(random_backpressure=False)
+    three_collector = StreamCollector(
+        random_backpressure=False, stream=dut.three.data)
+    five_collector = StreamCollector(
+        random_backpressure=False, stream=dut.five.data)
     # We don't delay in the input, so we can detect
     # the sender's completion from within the testbench.
-    sender = MultiPacketSender(random_delay=False)
+    sender = MultiPacketSender(random_delay=False, stream=dut.inbus)
     data = bytes(i % 256 for i in range(0, 50))
-    p = Packet(
+    p3 = Packet(
         Header(
             Flags(cwr=True, urg=True, rst=True, fin=True),
             stream=3,
@@ -94,7 +55,7 @@ def sim_main():
         ),
         body=data
     )
-    p0 = Packet(
+    p5 = Packet(
         Header(
             Flags(fin=True),
             stream=5,
@@ -108,20 +69,30 @@ def sim_main():
 
     sim.add_clock(1e-6)
 
-    sim.add_process(three_collector.collect(dut.three.data))
-    sim.add_process(five_collector.collect(dut.five.data))
-    sim.add_process(sender.send([p0, p, p0], dut.inbus))
-    sim.add_testbench(bench_stream3(dut, p))
+    sim.add_process(three_collector.collect())
+    sim.add_process(five_collector.collect())
+    sim.add_process(sender.send([p5, p3, p5]))
 
+    async def driver(ctx):
+        while not sender.done:
+            # Send all bytes
+            await ctx.tick()
+
+        # Then wait for receivers to flush
+        while ctx.get(dut.three.data.valid) or ctx.get(dut.five.data.valid):
+            await ctx.tick()
+
+        # All data should be collected.
+    sim.add_testbench(driver)
     with sim.write_vcd(sys.stdout):
         sim.run()
 
     # After the simulation completes -- the sender is done --
     # we still should only have collected only
     # the data from the packet on stream 3...
-    three_collector.assert_eq(p.body)
+    three_collector.assert_eq(p3.body)
     # ...and the data from both stream-5 packets on stream 5.
-    five_collector.assert_eq(2 * p0.body)
+    five_collector.assert_eq(2 * p5.body)
 
 
 if __name__ == "__main__":

--- a/almost_tcp/packet_stops_test.py
+++ b/almost_tcp/packet_stops_test.py
@@ -57,9 +57,11 @@ if __name__ == "__main__":
     import sys
 
     sim = Simulator(dut)
-    body_collector = StreamCollector(random_backpressure=True)
-    packets_collector = StreamCollector(random_backpressure=True)
-    sender = PacketSender(random_delay=True)
+    body_collector = StreamCollector(
+        random_backpressure=True, stream=dut.packet.data)
+    packets_collector = StreamCollector(
+        random_backpressure=True, stream=dut.outbus)
+    sender = PacketSender(random_delay=True, stream=dut.inbus)
     data = bytes(i % 256 for i in range(0, 260))
     p = Packet(
         Header(
@@ -74,9 +76,9 @@ if __name__ == "__main__":
     )
 
     sim.add_clock(1e-6)
-    sim.add_process(sender.send(p, dut.inbus))
-    sim.add_process(body_collector.collect(dut.packet.data))
-    sim.add_process(packets_collector.collect(dut.outbus))
+    sim.add_process(sender.send(p))
+    sim.add_process(body_collector.collect())
+    sim.add_process(packets_collector.collect())
     sim.add_testbench(bench(dut, body_collector, packets_collector, p))
 
     with sim.write_vcd(sys.stdout):

--- a/http_server/simple_led_http_test.py
+++ b/http_server/simple_led_http_test.py
@@ -52,8 +52,8 @@ def test_ok_handling():
 
     sim.add_testbench(driver)
 
-    collector = StreamCollector()
-    sim.add_process(collector.collect(dut.session.outbound.data))
+    collector = StreamCollector(stream=dut.session.outbound.data)
+    sim.add_process(collector.collect())
 
     # Doesn't appear to be a way to _remove_ a testbench;
     # I guess .reset() is "just" to allow a different initial state?

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ regex
 # Dev dependencies:
 flake8
 pytest
+hypothesis


### PR DESCRIPTION
- `HeaderSwizzle` to convert between little-endian and big-endian.
- `hypothesis` generator for packets
- Don't spuriously change from "ready" to "not ready", or "valid" to "not valid"; act like a queue.
- Add a `PacketCollector`, that collects and decodes `Packet`s from a stream
- Support `PacketSignature` in `MultiPacketSender`; support sending to components that deal in decoded packets