### PR TITLE
Not TCP

### DIFF
--- a/not_tcp/host.py
+++ b/not_tcp/host.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+import struct
+
+
+@dataclass
+class Header:
+    """
+    Not TCP header.
+    """
+
+    start: bool
+    end: bool
+    to_host: bool
+
+    session: int
+    length: int
+
+    def __len__(cls):
+        return 3
+
+    def to_bytes(self) -> bytes:
+        flags = 0
+        flags += 1 if self.start else 0
+        flags += 2 if self.end else 0
+        flags += 4 if self.to_host else 0
+        return struct.pack("BBB", flags, self.session, self.length)
+
+    def from_bytes(buffer: bytes) -> "Header":
+        (flags, session, length) = struct.unpack("BBB", buffer)
+        return Header(
+            start=bool(flags & 1),
+            end=bool(flags & 2),
+            to_host=bool(flags & 4),
+            session=session,
+            length=length,
+        )
+
+
+@dataclass
+class Packet:
+    """
+    Not TCP packet.
+    """
+
+    start: bool = False
+    end: bool = False
+    to_host: bool = False
+
+    session: int = 0
+    body: bytes = bytes()
+
+    def __len__(self):
+        return len(Header) + len(self.body)
+
+    def header(self) -> Header:
+        assert self.session >= 0
+        assert self.session < 256
+
+        return Header(self.start, self.end, self.to_host, self.session,
+                      length=len(self.body))
+
+    def to_bytes(self) -> bytes:
+        return self.header.to_bytes() + self.body

--- a/not_tcp/host.py
+++ b/not_tcp/host.py
@@ -60,4 +60,4 @@ class Packet:
                       length=len(self.body))
 
     def to_bytes(self) -> bytes:
-        return self.header.to_bytes() + self.body
+        return self.header().to_bytes() + self.body

--- a/not_tcp/host.py
+++ b/not_tcp/host.py
@@ -12,7 +12,7 @@ class Header:
     end: bool
     to_host: bool
 
-    session: int
+    stream: int
     length: int
 
     def __len__(cls):
@@ -23,15 +23,15 @@ class Header:
         flags += 1 if self.start else 0
         flags += 2 if self.end else 0
         flags += 4 if self.to_host else 0
-        return struct.pack("BBB", flags, self.session, self.length)
+        return struct.pack("BBB", self.stream, self.length, flags)
 
     def from_bytes(buffer: bytes) -> "Header":
-        (flags, session, length) = struct.unpack("BBB", buffer)
+        (stream, length, flags) = struct.unpack("BBB", buffer)
         return Header(
             start=bool(flags & 1),
             end=bool(flags & 2),
             to_host=bool(flags & 4),
-            session=session,
+            stream=stream,
             length=length,
         )
 
@@ -46,17 +46,17 @@ class Packet:
     end: bool = False
     to_host: bool = False
 
-    session: int = 0
+    stream: int = 0
     body: bytes = bytes()
 
     def __len__(self):
         return len(Header) + len(self.body)
 
     def header(self) -> Header:
-        assert self.session >= 0
-        assert self.session < 256
+        assert self.stream >= 0
+        assert self.stream < 256
 
-        return Header(self.start, self.end, self.to_host, self.session,
+        return Header(self.start, self.end, self.to_host, self.stream,
                       length=len(self.body))
 
     def to_bytes(self) -> bytes:

--- a/not_tcp/host.py
+++ b/not_tcp/host.py
@@ -17,7 +17,7 @@ class Header:
 
     flags: Flag
 
-    stream: int
+    stream_id: int
     length: int
 
     @classmethod
@@ -28,13 +28,13 @@ class Header:
         return 3
 
     def to_bytes(self) -> bytes:
-        return struct.pack("BBB", self.stream, self.length, self.flags)
+        return struct.pack("BBB", self.stream_id, self.length, self.flags)
 
     def from_bytes(buffer: bytes) -> "Header":
         (stream, length, flags) = struct.unpack("BBB", buffer)
         return Header(
             flags=Flag(flags),
-            stream=stream,
+            stream_id=stream,
             length=length,
         )
 
@@ -47,7 +47,7 @@ class Packet:
 
     flags: Flag = Flag(0)
 
-    stream: int = 0
+    stream_id: int = 0
     body: bytes = bytes()
 
     @classmethod
@@ -55,7 +55,7 @@ class Packet:
         assert header.length == len(body), f"{header.length} != {len(body)}"
         return Packet(
             flags=header.flags,
-            stream=header.stream,
+            stream_id=header.stream_id,
             body=body
         )
 
@@ -63,10 +63,10 @@ class Packet:
         return len(Header) + len(self.body)
 
     def header(self) -> Header:
-        assert self.stream >= 0
-        assert self.stream < 256
+        assert self.stream_id >= 0
+        assert self.stream_id < 256
 
-        return Header(self.flags, self.stream, length=len(self.body))
+        return Header(self.flags, self.stream_id, length=len(self.body))
 
     def to_bytes(self) -> bytes:
         return self.header().to_bytes() + self.body

--- a/not_tcp/host.py
+++ b/not_tcp/host.py
@@ -4,9 +4,9 @@ from enum import IntFlag
 
 
 class Flag(IntFlag):
-    START = IntFlag(1)
-    END = IntFlag(2)
-    TO_HOST = IntFlag(4)
+    START = 1
+    END = 2
+    TO_HOST = 4
 
 
 @dataclass

--- a/not_tcp/not_tcp.py
+++ b/not_tcp/not_tcp.py
@@ -168,9 +168,15 @@ class StreamStop(Component):
             with m.State("read-body"):
                 m.next = "read-body"
                 connect(m, self.bus.upstream, input_limiter.inbound)
+                with m.If(stream != Const(self._stream_id)):
+                    # Disconnect from the input buffer, just discard the data:
+                    m.d.comb += [
+                        input_buffer.w_stream.valid.eq(0),
+                        input_limiter.outbound.ready.eq(1),
+                    ]
                 m.d.comb += input_limiter.start.eq(0)
                 with m.If(input_limiter.done):
-                    m.next = "read-len"
+                    m.next = "read-stream"
 
         with m.FSM(name="write"):
             bus = self.bus.downstream

--- a/not_tcp/not_tcp.py
+++ b/not_tcp/not_tcp.py
@@ -71,7 +71,7 @@ class BusRoot(Component):
     """
     Root of a Not TCP bus.
     Connects the (host) serial lines to the (device-local) bus
-    and sorts packets between upstrema and downstream.
+    and sorts packets between upstream and downstream.
     """
 
     bus: Out(BusStopSignature())
@@ -118,8 +118,10 @@ class StreamStop(Component):
 
         connect(m, self.stop.outbound.data, output_buffer.w_stream)
         connect(m, input_buffer.r_stream, self.stop.inbound.data)
-        input_limiter = m.submodules.input_limiter = LimitForwarder()
-        output_limiter = m.submodules.output_limiter = LimitForwarder()
+        input_limiter = m.submodules.input_limiter = LimitForwarder(
+            width=8, max_count=256)
+        output_limiter = m.submodules.output_limiter = LimitForwarder(
+            width=8, max_count=256)
 
         # Default state: don't transfer any data.
         m.d.comb += [

--- a/not_tcp/not_tcp.py
+++ b/not_tcp/not_tcp.py
@@ -1,0 +1,100 @@
+"""
+Not TCP is a simple protocol for running HTTP/1.0 sessions over a
+serial stream.
+
+Each packet includes a short header: flags, a session ID, and a body-length.
+
+"""
+
+from amaranth import Module, Signal, unsigned, Const
+from amaranth.lib.wiring import Component, In, Out, Signature
+from amaranth.lib import stream
+from amaranth.lib.data import UnionLayout, ArrayLayout, Struct
+from amaranth.lib.fifo import SyncFIFOBuffered
+import session
+
+
+class Flags(Struct):
+    """
+    Flags in a Not TCP header.
+    """
+
+    # Start-of-stream marker.
+    start: 1
+
+    # End-of-stream marker.
+    end: 1
+
+    # Direction marker: 0 for "client to server", 1 for "server to client"
+    direction: 1
+
+    # Additional bits for the future.
+    unused: 5
+
+
+class Header(Struct):
+    """
+    Layout of a Not TCP header.
+    """
+
+    flags: Flags
+
+    # Session identifier.
+    session: 8
+
+    # Length of the body following the header
+    # (bytes to the next header)
+    length: 8
+
+
+class BusStopSignature(Signature):
+    """
+    Signature of a stop on a Not TCP local bus.
+
+    Attributes
+    ----------
+    upstream:   Stream(8), In
+    downstream: Stream(8), Out
+    """
+
+    def __init__(self):
+        super().__init__({
+            "upstream": In(stream.Signature(8)),
+            "downstream": Out(stream.Signature(8)),
+        })
+
+
+class BusRoot(Component):
+    """
+    Root of a Not TCP bus.
+    Connects the (host) serial lines to the (device-local) bus
+    and sorts packets between upstrema and downstream.
+    """
+
+    bus: Out(BusStopSignature())
+    tx: Out(stream.Signature(8))
+    rx: In(stream.Signature(8))
+
+    def elaborate(self, platform):
+        m = Module()
+
+        return m
+
+
+class StreamStop(Component):
+    """
+    A stop for a Not TCP stream on the local bus.
+
+    Attributes
+    ----------
+    session: Inner interface
+    bus: Bus interface
+    """
+
+    session: Out(session.BidiSessionSignature().flipped())
+    bus: BusStopSignature()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        return m

--- a/not_tcp/not_tcp.py
+++ b/not_tcp/not_tcp.py
@@ -81,6 +81,11 @@ class BusRoot(Component):
     def elaborate(self, platform):
         m = Module()
 
+        # Degenerate implementation for a single stop with no arbitration,
+        # or with all stops forwarding unmatched packets.
+        connect(m, self.rx, self.bus.upstream)
+        connect(m, self.bus.downstream, self.tx)
+
         return m
 
 

--- a/not_tcp/not_tcp.py
+++ b/not_tcp/not_tcp.py
@@ -160,6 +160,7 @@ class StreamStop(Component):
                 with m.If(self.stop.outbound.active):
                     m.next = "open"
             with m.State("open"):
+                m.next = "open"
                 m.d.comb += [
                     self.stop.inbound.active.eq(1),
                     connected.eq(1),
@@ -173,8 +174,8 @@ class StreamStop(Component):
                     # Consume the input buffer.
                     m.next = "client-done"
             with m.State("client-done"):
-                m.d.comb += [connected.eq(1)]
                 m.next = "client-done"
+                m.d.comb += [connected.eq(1)]
                 with m.If(~self.stop.outbound.active):
                     # Server is also done, and flushed.
                     m.next = "flush"
@@ -186,8 +187,8 @@ class StreamStop(Component):
                         (stream == Const(self._stream_id))):
                     m.next = "flush"
             with m.State("flush"):
-                m.d.comb += [connected.eq(1)]
                 m.next = "flush"
+                m.d.comb += [connected.eq(1)]
                 with m.If(
                     (read_len == Const(0)) &
                     (input_buffer.r_level == Const(0)) &

--- a/not_tcp/not_tcp.py
+++ b/not_tcp/not_tcp.py
@@ -126,8 +126,6 @@ class StreamStop(Component):
         # Default state: don't transfer any data.
         m.d.comb += [
             self.stop.inbound.active.eq(0),
-            input_buffer.r_stream.ready.eq(0),
-            output_buffer.r_stream.ready.eq(0),
             input_limiter.start.eq(0),
             output_limiter.start.eq(0),
         ]
@@ -164,7 +162,6 @@ class StreamStop(Component):
                     # the byte following that.
                     m.d.comb += input_limiter.count.eq(read_len)
                     m.d.comb += input_limiter.start.eq(1)
-                    connect(m, self.bus.upstream, input_limiter.inbound)
                     # TODO: Ignore / block / forward-to-null
                     # if session is inactive
                     m.next = "read-body"

--- a/not_tcp/not_tcp.py
+++ b/not_tcp/not_tcp.py
@@ -26,7 +26,7 @@ class Flags(Struct):
     end: 1
 
     # Direction marker: 0 for "client to server", 1 for "server to client"
-    direction: 1
+    to_host: 1
 
     # Additional bits for the future.
     unused: 5
@@ -91,10 +91,18 @@ class StreamStop(Component):
     bus: Bus interface
     """
 
-    session: Out(session.BidiSessionSignature().flipped())
-    bus: BusStopSignature()
+    stop: Out(session.BidiSessionSignature().flip())
+    bus: Out(BusStopSignature())
+
+    def __init__(self, stream_id):
+        super().__init__()
+        self._stream_id = stream_id
 
     def elaborate(self, platform):
         m = Module()
+
+        # TODO: Stub, to get sim passing
+        toggle = Signal(1)
+        m.d.sync += toggle.eq(~toggle)
 
         return m

--- a/not_tcp/not_tcp_test.py
+++ b/not_tcp/not_tcp_test.py
@@ -83,9 +83,14 @@ def test_single_stop():
         (p, remainder) = host.Packet.from_bytes(rcvd)
         packets += [p]
         rcvd = remainder
-    bodies = map(lambda p: p.body, packets)
-    body = functools.reduce(lambda a, b: a + b, bodies, bytes())
-    assert body == p4.body
+    bodies = bytes()
+    for packet in packets:
+        assert p.to_host
+        assert p.stream == 0
+        bodies += p.body
+    assert p[0].start
+    assert p[:-1].end
+    assert bodies == p4.body
 
 
 if __name__ == "__main__":

--- a/not_tcp/not_tcp_test.py
+++ b/not_tcp/not_tcp_test.py
@@ -27,34 +27,34 @@ def test_single_stop():
     p1 = host.Packet(start=True, stream=2,
                      body=bytes(i for i in range(0, 10)))
     # Host-to-device, starting and ending stream 3
-    # p2 = host.Packet(start=True, end=True, stream=3,
-    #                  body=bytes(i for i in range(10, 15)))
-    # # Host-to-device, middle of stream 2
+    p2 = host.Packet(start=True, end=True, stream=3,
+                     body=bytes(i for i in range(10, 15)))
+    # Host-to-device, middle of stream 2
     p3 = host.Packet(stream=2, body=bytes(i for i in range(15, 18)))
     # # device-to-host, stream 2; start and end markers, it's all the data
-    # p4 = host.Packet(start=True, end=True, stream=2,
-    #                  body=bytes(i for i in range(18, 28)))
-    # # host-to-device, stream 2: end marker only
+    p4 = host.Packet(start=True, end=True, stream=2,
+                     body=bytes(i for i in range(18, 28)))
+    # host-to-device, stream 2: end marker only
     p5 = host.Packet(end=True, stream=2, body=bytes())
 
     async def driver(ctx):
         # Just the header for p1 should start the stream:
         await send_bus.send_active(p1.header().to_bytes())(ctx)
         # TODO: wait until "accepted"
-        # await ctx.tick().until(dut.stop.inbound.active)
+        await ctx.tick().until(dut.stop.inbound.active)
         # Accept the stream:
         ctx.set(dut.stop.outbound.active, 1)
         # And finish p1's body
         await send_bus.send_active(p1.body)(ctx)
 
         # Feed in p2:
-        # await send_bus.send_active(p2.to_bytes())(ctx)
+        await send_bus.send_active(p2.to_bytes())(ctx)
         # # and p3:
         await send_bus.send_active(p3.to_bytes())(ctx)
         # # Send p4 on the return path:
-        # await send_stop.send_active(p4.body)(ctx)
+        await send_stop.send_active(p4.body)(ctx)
         # # And mark the stream as closed:
-        # ctx.set(dut.stop.outbound.active, 0)
+        ctx.set(dut.stop.outbound.active, 0)
         #
         # # And then send p5 to hang up the inbound path:
         await send_bus.send_active(p5.to_bytes())(ctx)
@@ -74,11 +74,14 @@ def test_single_stop():
     collect_stop.assert_eq(
         p1.body + p3.body + p5.body
     )
+    # TODO: Stream multiplexing, to the next stops on the bus
+
     # And the bus should have received the packet for stream 3
     # (which continued around the bus),
     # then the packet sent for stream 2 (which was generated)
     # collect_bus.assert_eq(
-    #     p2.to_bytes() + p4.to_bytes()
+    # #     # p2.to_bytes() +
+    #     p4.to_bytes()
     # )
 
 

--- a/not_tcp/not_tcp_test.py
+++ b/not_tcp/not_tcp_test.py
@@ -70,15 +70,15 @@ def test_single_stop():
 
     # After simulation is complete...
     # The stop should have received all the packets for this stream:
-    collect_stop.assert_eq(
-        p1.body + p3.body + p5.body
-    )
+    # collect_stop.assert_eq(
+    #     p1.body + p3.body + p5.body
+    # )
     # And the bus should have received the packet for stream 3
     # (which continued around the bus),
     # then the packet sent for stream 2 (which was generated)
-    collect_bus.assert_eq(
-        p2.to_bytes() + p4.to_bytes()
-    )
+    # collect_bus.assert_eq(
+    #     p2.to_bytes() + p4.to_bytes()
+    # )
 
 
 if __name__ == "__main__":

--- a/not_tcp/not_tcp_test.py
+++ b/not_tcp/not_tcp_test.py
@@ -1,0 +1,85 @@
+import sys
+
+from amaranth.sim import Simulator
+
+import host
+from not_tcp import StreamStop
+from stream_fixtures import StreamSender, StreamCollector
+
+
+def test_single_stop():
+    dut = StreamStop(2)
+
+    sim = Simulator(dut)
+    # Passively collect the data that comes in to this stop:
+    collect_stop = StreamCollector(dut.stop.inbound.data)
+    sim.add_process(collect_stop.collect())
+    # And the data that continues on the bus:
+    collect_bus = StreamCollector(dut.bus.downstream)
+    sim.add_process(collect_bus.collect())
+
+    # Provide senders for "upstream on the bus" and "from this stop"
+    send_stop = StreamSender(dut.stop.outbound.data)
+    send_bus = StreamSender(dut.bus.upstream)
+
+    # The packet sequence we'll use:
+    # Host-to-device, starting session 2
+    p1 = host.Packet(start=True, session=2,
+                     body=bytes(i for i in range(0, 10)))
+    # Host-to-device, starting and ending session 3
+    p2 = host.Packet(start=True, end=True, session=3,
+                     body=bytes(i for i in range(10, 15)))
+    # Host-to-device, middle of session 2
+    p3 = host.Packet(session=2, body=bytes(i for i in range(15, 18)))
+    # device-to-host, session 2; start and end markers, it's all the data
+    p4 = host.Packet(start=True, end=True, session=2,
+                     body=bytes(i for i in range(18, 28)))
+    # host-to-device, session 2: end marker only
+    p5 = host.Packet(end=True, session=2, body=bytes())
+
+    async def driver(ctx):
+        # Just the header for p1 should start the session:
+        await send_bus.send_active(p1.header().to_bytes())(ctx)
+        await ctx.tick().until(dut.stop.inbound.active)
+        # Accept the session:
+        ctx.set(dut.stop.outbound.active, 1)
+        # And finish p1's body
+        await send_bus.send_active(p1.body)
+
+        # Feed in p2:
+        await send_bus.send_active(p2.to_bytes())(ctx)
+        # and p3:
+        await send_bus.send_active(p3.to_bytes())(ctx)
+        # Send p4 on the return path:
+        await send_stop.send_active(p4.body)(ctx)
+        # And mark the session as closed:
+        ctx.set(dut.stop.outbound.active, 0)
+
+        # And then send p5 to hang up the inbound path:
+        await send_bus.send_active(p5.to_bytes())(ctx)
+
+        # Wait for everything to be flushed:
+        await ctx.tick().until(
+            ~dut.stop.inbound.active & ~dut.downstream.valid)
+
+    sim.add_testbench(driver)
+    sim.add_clock(1e-6)
+
+    with sim.write_vcd(sys.stdout):
+        sim.run_until(0.000100)  # 100us
+
+    # After simulation is complete...
+    # The stop should have received all the packets for this session:
+    collect_stop.assert_eq(
+        p1.body + p3.body + p5.body
+    )
+    # And the bus should have received the packet for session 3
+    # (which continued around the bus),
+    # then the packet sent for session 2 (which was generated)
+    collect_bus.assert_eq(
+        p2.to_bytes() + p4.to_bytes()
+    )
+
+
+if __name__ == "__main__":
+    test_single_stop()

--- a/not_tcp/not_tcp_test.py
+++ b/not_tcp/not_tcp_test.py
@@ -27,14 +27,14 @@ def test_single_stop():
     p1 = host.Packet(start=True, stream=2,
                      body=bytes(i for i in range(0, 10)))
     # Host-to-device, starting and ending stream 3
-    p2 = host.Packet(start=True, end=True, stream=3,
-                     body=bytes(i for i in range(10, 15)))
-    # Host-to-device, middle of stream 2
+    # p2 = host.Packet(start=True, end=True, stream=3,
+    #                  body=bytes(i for i in range(10, 15)))
+    # # Host-to-device, middle of stream 2
     p3 = host.Packet(stream=2, body=bytes(i for i in range(15, 18)))
-    # device-to-host, stream 2; start and end markers, it's all the data
-    p4 = host.Packet(start=True, end=True, stream=2,
-                     body=bytes(i for i in range(18, 28)))
-    # host-to-device, stream 2: end marker only
+    # # device-to-host, stream 2; start and end markers, it's all the data
+    # p4 = host.Packet(start=True, end=True, stream=2,
+    #                  body=bytes(i for i in range(18, 28)))
+    # # host-to-device, stream 2: end marker only
     p5 = host.Packet(end=True, stream=2, body=bytes())
 
     async def driver(ctx):
@@ -48,17 +48,17 @@ def test_single_stop():
         await send_bus.send_active(p1.body)(ctx)
 
         # Feed in p2:
-        await send_bus.send_active(p2.to_bytes())(ctx)
-        # and p3:
+        # await send_bus.send_active(p2.to_bytes())(ctx)
+        # # and p3:
         await send_bus.send_active(p3.to_bytes())(ctx)
-        # Send p4 on the return path:
-        await send_stop.send_active(p4.body)(ctx)
-        # And mark the stream as closed:
-        ctx.set(dut.stop.outbound.active, 0)
-
-        # And then send p5 to hang up the inbound path:
+        # # Send p4 on the return path:
+        # await send_stop.send_active(p4.body)(ctx)
+        # # And mark the stream as closed:
+        # ctx.set(dut.stop.outbound.active, 0)
+        #
+        # # And then send p5 to hang up the inbound path:
         await send_bus.send_active(p5.to_bytes())(ctx)
-
+        #
         # Wait for everything to be flushed:
         await ctx.tick().until(
             ~dut.stop.inbound.active & ~dut.bus.downstream.valid)

--- a/not_tcp/not_tcp_test.py
+++ b/not_tcp/not_tcp_test.py
@@ -24,18 +24,18 @@ def test_single_stop():
 
     # The packet sequence we'll use:
     # Host-to-device, starting stream 2
-    p1 = Packet(flags=Flag.START, stream=2,
+    p1 = Packet(flags=Flag.START, stream_id=2,
                 body=bytes(i for i in range(0, 10)))
     # Host-to-device, starting and ending stream 3
-    p2 = Packet(flags=Flag.START | Flag.END, stream=3,
+    p2 = Packet(flags=Flag.START | Flag.END, stream_id=3,
                 body=bytes(i for i in range(10, 15)))
     # Host-to-device, middle of stream 2
-    p3 = Packet(stream=2, body=bytes(i for i in range(15, 18)))
+    p3 = Packet(stream_id=2, body=bytes(i for i in range(15, 18)))
     # # device-to-host, stream 2; start and end markers, it's all the data
-    p4 = Packet(flags=Flag.START | Flag.END, stream=2,
+    p4 = Packet(flags=Flag.START | Flag.END, stream_id=2,
                 body=bytes(i for i in range(18, 28)))
     # host-to-device, stream 2: end marker only
-    p5 = Packet(flags=Flag.END, stream=2, body=bytes())
+    p5 = Packet(flags=Flag.END, stream_id=2, body=bytes())
 
     async def driver(ctx):
         # Just the header for p1 should start the stream:
@@ -85,7 +85,7 @@ def test_single_stop():
     bodies = bytes()
     for packet in packets:
         assert p.flags & Flag.TO_HOST
-        assert p.stream == 2
+        assert p.stream_id == 2
         bodies += packet.body
     assert packets[0].flags & Flag.START
     assert packets[-1].flags & Flag.END

--- a/session.py
+++ b/session.py
@@ -35,18 +35,20 @@ class BidiSessionSignature(Signature):
     The sequence of usage is as follows:
 
     - At reset, inbound.active and outbound.active are both zero.
-    - A new session starts with inbound.active raised
-    - The session manager wait for outbound.active to be raised before
-      passing data into inbound.data. inbound.data and outbound.data
-      perform flow control as usual
-    - Data flows for a while
-    - At the end of a session, inbound.active OR outbound.active deasserts,
-      after all data has been consumed (i.e. data.valid goes low for
-      the final time)
-    - The still-active end must continue consuming data until
-      the other .active goes low
-    - Once both .active are low, the session has been reset, and a new session
-      can proceed
+    - A new session becomes *half-open* when the client asserts inbound.active.
+    - Subsequently, the server asserts outbound.active.
+    - To end the session, both `inbound.active` and `outbound.active`
+      will de-assert. This can happen in either order, but they cannot assert
+      again until the beginning of the next session.
+    - Data may be pushed once the session is established:
+      - `inbound.data.valid` will not assert until both `active` signals
+        are asserted.
+      - `outbound.data.valid` must not assert until both `active signals
+        are asserted.
+    - Once the session is established, new data may appear (`.valid` asserted)
+      as long as the corresponding `.active` signal remains asserted.
+      Once an `.active` signal goes low, the corresponding `.valid` signal
+      will/must not re-assert until a new session is established.
     """
 
     def __init__(self):

--- a/session.py
+++ b/session.py
@@ -40,15 +40,16 @@ class BidiSessionSignature(Signature):
     - To end the session, both `inbound.active` and `outbound.active`
       will de-assert. This can happen in either order, but they cannot assert
       again until the beginning of the next session.
-    - Data may be pushed once the session is established:
-      - `inbound.data.valid` will not assert until both `active` signals
-        are asserted.
-      - `outbound.data.valid` must not assert until both `active signals
-        are asserted.
-    - Once the session is established, new data may appear (`.valid` asserted)
-      as long as the corresponding `.active` signal remains asserted.
-      Once an `.active` signal goes low, the corresponding `.valid` signal
-      will/must not re-assert until a new session is established.
+    - Once the session is established, data may flow according to the
+      `stream.Signature` protocol: a byte is transferred on each cycle
+      where `valid` and `ready` are both asserted.
+      Data must not flow until both `active` signals have been asserted.
+    - An `.active` signal must not deassert until all data from the
+      corresponding source has been read (i.e. until the corresponding
+      `.valid` has deasserted after transferring all bytes).
+    - Once an `active` signal has deasserted, it must not re-assert until
+      a new session has been established (i.e. the other signal has also
+      deasserted).
     """
 
     def __init__(self):

--- a/stream_fixtures.py
+++ b/stream_fixtures.py
@@ -2,7 +2,6 @@
 Test fixtures for sending and receiving in streams.
 """
 import random
-import sys
 from typing import Iterable
 
 __all__ = ["StreamCollector", "StreamSender"]

--- a/stream_utils.py
+++ b/stream_utils.py
@@ -21,6 +21,11 @@ class LimitForwarder(Component):
         m = Module()
 
         countdown = Signal(9)
+        # No transfer by default:
+        m.d.comb += [
+                self.inbound.ready.eq(0),
+                self.outbound.valid.eq(0),
+        ]
 
         with m.FSM():
             with m.State("idle"):

--- a/stream_utils.py
+++ b/stream_utils.py
@@ -1,0 +1,48 @@
+from amaranth import Module, Signal
+from amaranth.lib.wiring import Component, In, Out
+from amaranth.lib import stream
+
+
+class LimitForwarder(Component):
+    """
+    Forwards a limited number of bytes from one stream to another, then stops.
+
+    TODO: Documentation, parameterization
+    """
+
+    inbound: In(stream.Signature(8))
+    outbound: Out(stream.Signature(8))
+
+    count: In(9)
+    start: In(1)
+    done: Out(1)
+
+    def elaborate(self, _platform):
+        m = Module()
+
+        countdown = Signal(9)
+
+        with m.FSM():
+            with m.State("idle"):
+                m.next = "idle"
+                m.d.comb += self.done.eq(1)
+                with m.If(self.start):
+                    m.next = "run"
+                    m.d.sync += countdown.eq(self.count)
+            with m.State("run"):
+                m.next = "run"
+                m.d.comb += self.done.eq(0)
+                with m.If(countdown == 0):
+                    m.next = "idle"
+                with m.Else():
+                    # Doesn't want to connect()?
+                    m.d.comb += [
+                            self.inbound.ready.eq(self.outbound.ready),
+                            self.outbound.valid.eq(self.inbound.valid),
+                            self.outbound.payload.eq(self.inbound.payload),
+                    ]
+                    with m.If(self.outbound.ready & self.inbound.valid):
+                        # Byte was transferred
+                        m.d.sync += countdown.eq(countdown - 1)
+
+        return m

--- a/stream_utils_test.py
+++ b/stream_utils_test.py
@@ -7,7 +7,7 @@ from stream_fixtures import StreamSender, StreamCollector
 
 
 def test_limit_forward():
-    dut = LimitForwarder()
+    dut = LimitForwarder(width=8,max_count=80)
 
     sim = Simulator(dut)
     collector = StreamCollector(dut.outbound)

--- a/stream_utils_test.py
+++ b/stream_utils_test.py
@@ -1,0 +1,55 @@
+import sys
+
+from amaranth.sim import Simulator
+
+from stream_utils import LimitForwarder
+from stream_fixtures import StreamSender, StreamCollector
+
+
+def test_limit_forward():
+    dut = LimitForwarder()
+
+    sim = Simulator(dut)
+    collector = StreamCollector(dut.outbound)
+    sim.add_process(collector.collect())
+    sender = StreamSender(dut.inbound)
+    # TODO: use Hypothesis, generalize the test
+    sim.add_process(sender.send_passive(bytes(i for i in range(0, 100))))
+
+    async def driver(ctx):
+        # Tick a few times; should have no data
+        for _i in range(0, 10):
+            assert not ctx.get(dut.inbound.ready)
+            assert not ctx.get(dut.outbound.valid)
+            assert ctx.get(dut.done)
+            await ctx.tick()
+
+        # Send one block:
+        ctx.set(dut.count, 40)
+        ctx.set(dut.start, 1)
+        # Until the tick, still "done"...
+        assert ctx.get(dut.done)
+        await ctx.tick()
+        ctx.set(dut.start, 0)
+        assert not ctx.get(dut.done)
+        await ctx.tick().until(dut.done)
+        assert len(collector.body) == 40
+
+        # Send another block:
+        ctx.set(dut.count, 20)
+        ctx.set(dut.start, 1)
+        await ctx.tick()
+        ctx.set(dut.start, 0)
+        await ctx.tick().until(dut.done)
+
+        assert collector.body == bytes(i for i in range(0, 60))
+
+    sim.add_testbench(driver)
+    sim.add_clock(1e-6)
+
+    with sim.write_vcd(sys.stdout):
+        sim.run()
+
+
+if __name__ == "__main__":
+    test_limit_forward()


### PR DESCRIPTION
Server-side stream-to-session interpreter

Ignores packets for other streams, arranges the `active` lines in sequence.

In theory -- I only have so much faith in this test.

Please ignore all the "WIP" commits, this is admittedly a big chunk at once...
appropriate for squash merging.

- Additional stream fixture, for sending from the driver
- Stream utility: forward a limited number of bytes
- Sketch of 'not tcp', an even simpler serial-multiplexing protocol
- WIP: TDD on not TCP
- wip: Reorder packet to allow inline demuxing
- wip: non-state-aware stop
- wip: ntcp
- wip: ntcp; fix input issues
- wip: more fixes, pass local input
- wip: more fixes to session state
- send from session
