### PR TITLE
NTCP+HTTP server with sim test

### DIFF
--- a/ntcp_http.py
+++ b/ntcp_http.py
@@ -1,0 +1,67 @@
+from amaranth.lib.wiring import connect, Component, In, Out
+from amaranth.lib import stream
+from amaranth import Module
+from not_tcp.not_tcp import StreamStop
+from http_server.simple_led_http import SimpleLedHttp
+
+
+class NtcpHttpServer(Component):
+    """
+    A serial-to-HTTP server, suitable for synthesis.
+    """
+
+    tx: Out(stream.Signature(8))
+    rx: In(stream.Signature(8))
+
+    red: Out(8)
+    green: Out(8)
+    blue: Out(8)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # Packet bus:
+        # Just a single stream processor for now.
+        # the bus doesn't properly handle multiple stops.
+        stop = m.submodules.ntcp_stop = StreamStop(stream_id=1)
+        m.d.comb += [
+            self.tx.valid.eq(stop.bus.downstream.valid),
+            self.tx.payload.eq(stop.bus.downstream.payload),
+            stop.bus.downstream.ready.eq(self.tx.ready),
+
+            stop.bus.upstream.valid.eq(self.rx.valid),
+            stop.bus.upstream.payload.eq(self.rx.payload),
+            self.rx.ready.eq(stop.bus.upstream.ready),
+        ]
+
+        # Actual HTTP processing:
+        http = m.submodules.http = SimpleLedHttp()
+
+        # There's something funky going on with the session lines;
+        # connect() should work, but it doesn't.
+        # If we do the connections manually, the simulator hangs on cycle 4.
+
+        # On its own, this doesn't work; the active lines don't get connected.
+        # connect(m, stop.stop, http.session)
+        # So let's try connecting the session-active lines manually:
+        m.d.comb += [
+            http.session.inbound.active.eq(stop.stop.inbound.active),
+            http.session.inbound.data.payload.eq(
+                stop.stop.inbound.data.payload),
+            http.session.inbound.data.valid.eq(stop.stop.inbound.data.valid),
+            stop.stop.inbound.data.ready.eq(http.session.inbound.data.ready),
+
+            stop.stop.outbound.active.eq(http.session.outbound.active),
+            stop.stop.outbound.data.payload.eq(
+                http.session.outbound.data.payload),
+            stop.stop.outbound.data.valid.eq(http.session.outbound.data.valid),
+            http.session.outbound.data.ready.eq(stop.stop.outbound.data.ready),
+        ]
+
+        m.d.comb += [
+            self.red.eq(http.red),
+            self.green.eq(http.green),
+            self.blue.eq(http.blue),
+        ]
+
+        return m

--- a/ntcp_http_test.py
+++ b/ntcp_http_test.py
@@ -1,0 +1,79 @@
+
+from amaranth.sim import Simulator
+
+from not_tcp.host import Packet, Flag
+from sim_server import SimServer
+from ntcp_http import NtcpHttpServer
+from stream_fixtures import StreamSender, StreamCollector
+
+
+def test_sim_without_fixture():
+    dut = NtcpHttpServer()
+    sim = Simulator(dut)
+    sim.add_clock(1e-6)
+
+    sender = StreamSender(dut.rx)
+    receiver = StreamCollector(dut.tx)
+
+    request = (b"GET /unmapped HTTP/1.0\r\n"
+               b"Content-Length: 3\r\n"
+               b"\r\n"
+               b"\r\n"
+               b"123\r\n"
+               )
+    data = Packet(stream_id=1, flags=Flag.START | Flag.END, body=request)
+
+    sim.add_process(sender.send_passive(data.to_bytes()))
+    sim.add_process(receiver.collect())
+
+    async def driver(ctx):
+        # while not sender.done:
+        #     await ctx.tick()
+        # Arbitrary delay to flush output before exiting:
+        for i in range(0, 4096):
+            await ctx.tick()
+    sim.add_testbench(driver)
+
+    sim.run()
+
+
+def test_sim():
+    dut = NtcpHttpServer()
+
+    with SimServer(dut, dut.tx, dut.rx) as srv:
+        p1 = Packet(flags=Flag.START | Flag.END, stream_id=1,
+                    body=(
+                        b"GET /unmapped HTTP/1.0\r\n"
+                        b"Content-Length: 3\r\n"
+                        b"\r\n"
+                        b"\r\n"
+                        b"123\r\n"))
+        srv.send(p1.to_bytes())
+
+        received_bytes = bytes()
+        packets = []
+        import sys
+        # We shouldn't have more than 100 packets for this test.
+        for i in range(100):
+            received_bytes += srv.recv()
+            (packet, remainder) = Packet.from_bytes(received_bytes)
+            if packet is not None:
+                sys.stderr.write(f"packet: {packet}\n")
+                received_bytes = remainder
+                packets += [packet]
+                if packet.end:
+                    break
+
+        packet_bodies = bytes()
+        for i in range(len(packets)):
+            packet = packets[i]
+            assert packet.to_host
+            assert packet.start == (
+                i == 0), f"start {packet.start} for packet {i}"
+            assert packet.end == (
+                i == len(packets)-1), f"end {packet.end} for packet {i}"
+            assert packet.to_host
+
+            packet_bodies += packet.body
+        response = packet_bodies.decode("utf-8")
+        assert response.startswith("HTTP/1.0"), response


### PR DESCRIPTION
Integrate the HTTP server with the NTCP endpoint. Use `SimServer` to test the combination.